### PR TITLE
Handle non-GET requests with a generic response

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/acme/autocert"
@@ -72,7 +73,22 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	host := r.Host
 	dir := filepath.Join(h.dir, host)
-	http.FileServer(http.Dir(dir)).ServeHTTP(w, r)
+	if r.Method == http.MethodGet {
+		http.FileServer(http.Dir(dir)).ServeHTTP(w, r)
+	} else {
+		writeSuccess(w, r)
+	}
+}
+
+func writeSuccess(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.Header.Get("Accept"), "application/json") {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, `{"ok": true}`)
+	} else {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "Success!")
+	}
 }
 
 type RequestLog struct {


### PR DESCRIPTION
Every incoming request gets written to the filesystem already. This is the first thing the server does when a request comes in. If this write fails, the server panics and does not complete the request, even if the request is read-only (aka GET method). The most likely failure state is runnning out of disk space. If this happens, all sites hosted on the server will become unresponsive. This is a good thing. We should be made aware right away so that we can quickly fix the problem. It should relatively easy to redeploy in read-only mode while the fix is underway. Sorry for the tangent.

The important thing to know is that we are already logging the entirety of the request. This allows us to design asynchronous systems to process these logs and apply any necessary changes to the system, which is the trend right now in the application space anyway.

Another added benifit of this architecture is that it doesn't leak implementation details. All the client needs to know is that the message got delivered and that they do not need to try again.